### PR TITLE
Fix backup history exit logic

### DIFF
--- a/image-scraper.py
+++ b/image-scraper.py
@@ -167,7 +167,7 @@ def fetch_images_from_keyword(
             return
 
 
-def backup_history(*args, verbosity=0):
+def backup_history(signum=None, frame=None, verbosity=0):
     download_history = open(
         os.path.join(output_dir, 'download_history.pickle'), 'wb'
     )
@@ -179,7 +179,7 @@ def backup_history(*args, verbosity=0):
     download_history.close()
     if verbosity > 0:
         logging.info('Dumped download history')
-    if args:
+    if signum is not None:
         exit(0)
 
 
@@ -292,6 +292,6 @@ if __name__ == "__main__":
                 args.limit,
                 args.file_prefix
             )
-            backup_history(args.verbosity)
+            backup_history(verbosity=args.verbosity)
             time.sleep(10)
         inputFile.close()


### PR DESCRIPTION
## Summary
- prevent premature exit when backing up history
- call backup with keyword argument for verbosity

## Testing
- `python3 -m py_compile image-scraper.py`

------
https://chatgpt.com/codex/tasks/task_e_68456b6da240832aa76439f43a694308